### PR TITLE
Computerコンストラクタのテスト

### DIFF
--- a/src/OpenMps/Computer.hpp
+++ b/src/OpenMps/Computer.hpp
@@ -434,7 +434,9 @@ namespace { namespace OpenMps
 	template<typename POSITION_WALL, typename POSITION_WALL_PRE>
 	class Computer final
 	{
+#ifdef TEST_DENSITY
 	  friend class DensityTest;
+#endif
 
 	private:
 		// 粒子リスト

--- a/src/OpenMps/Computer.hpp
+++ b/src/OpenMps/Computer.hpp
@@ -434,6 +434,8 @@ namespace { namespace OpenMps
 	template<typename POSITION_WALL, typename POSITION_WALL_PRE>
 	class Computer final
 	{
+	  friend class DensityTest;
+
 	private:
 		// 粒子リスト
 		std::vector<Particle> particles;

--- a/src/OpenMps/test/test_ComputerDensity.cpp
+++ b/src/OpenMps/test/test_ComputerDensity.cpp
@@ -7,7 +7,6 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include "../Computer.hpp"
 #include "../Particle.hpp"
-#include "../ComputingCondition.hpp"
 #include <iostream>
 
 namespace{
@@ -19,8 +18,6 @@ namespace{
 				const double tooNearCoefficient = 1.0;
 #endif
 
-				const double startTime = 0.0;
-				const double endTime = 0.5;
 				const double outputInterval = 1.0;
 				const std::size_t minStepCountPerOutput = 10;
 				const double maxDt = outputInterval / minStepCountPerOutput;
@@ -66,13 +63,13 @@ namespace{
 			// それぞれのテストケースTEST_Fが呼ばれる直前にSetUpで初期化される
 			virtual void SetUp(){
 
-		auto&& condition = OpenMps::ComputingCondition(
-#ifndef PRESSURE_EXPLICIT
-				eps,
-#endif
-				startTime, endTime,
-				outputInterval
-				);
+//		auto&& condition = OpenMps::ComputingCondition(
+//#ifndef PRESSURE_EXPLICIT
+//				eps,
+//#endif
+//				startTime, endTime,
+//				outputInterval
+//				);
 
 		auto&& environment = OpenMps::Environment(maxDt, courant,
 #ifdef ARTIFICIAL_COLLISION_FORCE
@@ -127,11 +124,11 @@ namespace{
 	TEST_F(DensityTest, FieldEnvironment){
 		auto env = computer->GetEnvironment();
 
-		// Environment TODO: PRESSURE_EXPLICITのifdef
+		// Environment TODO: 時間刻みdt,dxについて, PRESSURE_EXPLICITのifdef
 		const double dt_grav = std::sqrt(2.0*l0/g);
 		ASSERT_LE( env.MaxDt, dt_grav ); // PRESSURE_EXPLICITで分岐必要
-
 		ASSERT_DOUBLE_EQ( env.MaxDx, l0*courant ); // PRESSURE_EXPLICITで分岐必要
+
 		ASSERT_DOUBLE_EQ( env.L_0, l0 );
 		ASSERT_DOUBLE_EQ( env.R_e, r_eByl_0*l0 );
 		ASSERT_DOUBLE_EQ( env.G[OpenMps::AXIS_X], 0.0 );
@@ -164,8 +161,20 @@ namespace{
 		}
 	}
 
+	// アクセッサが適切か/フィールドに設定されているか for Computer
+	TEST_F(DensityTest, FieldComputer){
+#ifndef PRESSURE_EXPLICIT
+      // 圧力方程式の許容誤差
+      ASSERT_EQ_DOUBLE(computer->allowableResidual, eps);
+#endif
+      // TODO: grid もここでテストすべきか？: 粒子数密度のテストするなら、サイズくらいはテストすべきだと思った
+//			grid(env.NeighborLength, env.L_0, env.MinX, env.MaxX),
+//			positionWall(posWall),
+//			positionWallPre(posWallPre)
+	
+  }
 
-	}//openmps
+  }//openmps
 }//anonymas
 
 	///#ifndef PRESSURE_EXPLICIT
@@ -178,7 +187,3 @@ namespace{
 	///				const double tooNearCoefficient = 1.0;
 	///#endif
 	///
-	///				const double startTime = 0.0;
-	///				const double endTime = 0.5;
-	///				const double outputInterval = 0.0;
-	///				const std::size_t minStepCountPerOutput = 100;

--- a/src/OpenMps/test/test_ComputerDensity.cpp
+++ b/src/OpenMps/test/test_ComputerDensity.cpp
@@ -8,8 +8,42 @@
 #include "../Computer.hpp"
 #include "../Particle.hpp"
 #include "../ComputingCondition.hpp"
+#include <iostream>
 
 namespace{
+#ifndef PRESSURE_EXPLICIT
+				const double eps = 1e-10;
+#endif
+#ifdef ARTIFICIAL_COLLISION_FORCE
+				const double tooNearRatio = 1.0;
+				const double tooNearCoefficient = 1.0;
+#endif
+
+				const double startTime = 0.0;
+				const double endTime = 0.5;
+				const double outputInterval = 1.0;
+				const std::size_t minStepCountPerOutput = 10;
+				const double maxDt = outputInterval / minStepCountPerOutput;
+				const double courant = 0.1;
+
+				const double l0 = 0.001;
+				const double g = 9.8;
+				// 計算ステップから指定した時間スケール, dt = maxDt = 0.100
+				// 重力加速度による時間スケール, dt = sqrt(2*l0/g) = 0.0143..
+
+				const double rho = 998.2;
+				const double nu = 1.004e-06;
+				const double r_eByl_0 = 2.4;
+				const double surfaceRatio = 0.95;
+				const double minX = -0.004;
+				const double minZ = -0.004;
+				const double maxX = 0.053;
+				const double maxZ = 0.1;
+
+#ifdef PRESSURE_EXPLICIT
+					const double c = 1.0;
+#endif
+
 	namespace OpenMps{
 	double positionWall(std::size_t, double, double){
 		return 0.0;
@@ -25,39 +59,8 @@ namespace{
 	{
 		protected:
 			OpenMps::Computer<POS_WALL,POS_WALL_PRE> *computer;
-
 			// それぞれのテストケースTEST_Fが呼ばれる直前にSetUpで初期化される
 			virtual void SetUp(){
-				printf("Setup\n");
-
-#ifndef PRESSURE_EXPLICIT
-				const double eps = 1e-10;
-#endif
-#ifdef ARTIFICIAL_COLLISION_FORCE
-				const double tooNearRatio = 1.0;
-				const double tooNearCoefficient = 1.0;
-#endif
-
-				const double startTime = 0.0;
-				const double endTime = 0.5;
-				const double outputInterval = 0.0;
-				const std::size_t minStepCountPerOutput = 100;
-				const double courant = 0.1;
-				const double l0 = 0.001;
-
-				const double g = 9.8;
-				const double rho = 998.2;
-				const double nu = 1.004e-06;
-				const double r_eByl_0 = 2.4;
-				const double surfaceRatio = 0.95;
-				const double minX = -0.004;
-				const double minZ = -0.004;
-				const double maxX = 0.053;
-				const double maxZ = 0.1;
-
-#ifdef PRESSURE_EXPLICIT
-	const double c = 1.0;
-#endif
 
 		auto&& condition = OpenMps::ComputingCondition(
 #ifndef PRESSURE_EXPLICIT
@@ -67,7 +70,7 @@ namespace{
 				outputInterval
 				);
 
-		auto&& environment = OpenMps::Environment(outputInterval / minStepCountPerOutput, courant,
+		auto&& environment = OpenMps::Environment(maxDt, courant,
 #ifdef ARTIFICIAL_COLLISION_FORCE
 			tooNearRatio, tooNearCoefficient,
 #endif
@@ -88,57 +91,51 @@ namespace{
 			positionWall, positionWallPre);
 
 			computer = new OpenMps::Computer<POS_WALL,POS_WALL_PRE>(std::move(comp));
-			}
 
-			virtual void TearDown(){
-				printf("TearDown\n");
-				delete computer;
-			}
+		}
 
-			void searchNeighbor(){
-				computer->SearchNeighbor();
-			}
-
-			void computeNeighborDensities(){
-				computer->ComputeNeighborDensities();
-			}
+		virtual void TearDown(){
+			delete computer;
+		}
   };
 
-	TEST_F(DensityTest,calcDensity){
-		std::vector<OpenMps::Particle> particles;
+	TEST_F(DensityTest, EnvConstructor){
+		auto env = computer->GetEnvironment();
 
-		// 粒子を作成して入れていく
-		const double l0 = 0.1*1e-3; // 0.1 mm
-//		const double re = 2.1*l0;
-		const int nx = 7;
-		const int ny = 7;
+		// Environment TODO: PRESSURE_EXPLICITのifdef
+		const double dt_grav = std::sqrt(2.0*l0/g);
+		ASSERT_LE( env.MaxDt, dt_grav ); // PRESSURE_EXPLICITで分岐必要
 
-		// 1辺l0, nx*nyの正方格子状に粒子を配置
-		for(int j = 0; j < ny; ++j){
-			for(int i = 0; i < nx; ++i){
-				auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
-				particle.X()[OpenMps::AXIS_X] = i*l0;
-				particle.X()[OpenMps::AXIS_Z] = j*l0;;
-
-				particle.U()[OpenMps::AXIS_X] = 0.0;
-				particle.U()[OpenMps::AXIS_Z] = 0.0;
-				particle.P() = 0.0;
-				particle.N() = 0.0;
-
-				particles.push_back(std::move(particle));
-			}
-		}
-		computer->AddParticles(std::move(particles));
-
-//				computer.ForwardTime();
-		searchNeighbor();
-		computeNeighborDensities();
-
-		// 24番目の粒子を狙う
-		// 粒子数を表示
-		std::cout << particles.size() << " particles" << std::endl;
-
-	}
+		ASSERT_DOUBLE_EQ( env.MaxDx, l0*courant ); // PRESSURE_EXPLICITで分岐必要
+		ASSERT_DOUBLE_EQ( env.L_0, l0 );
+		ASSERT_DOUBLE_EQ( env.R_e, r_eByl_0*l0 );
+		ASSERT_DOUBLE_EQ( env.G[0], 0.0 );
+		ASSERT_DOUBLE_EQ( env.G[1], -g );
+		ASSERT_DOUBLE_EQ( env.Rho, rho );
+		ASSERT_DOUBLE_EQ( env.Nu, nu );
+		ASSERT_DOUBLE_EQ( env.SurfaceRatio, surfaceRatio );
+		ASSERT_DOUBLE_EQ( env.MinX[0], minX );
+		ASSERT_DOUBLE_EQ( env.MinX[1], minZ );
+		ASSERT_DOUBLE_EQ( env.MaxX[0], maxX );
+		ASSERT_DOUBLE_EQ( env.MaxX[1], maxZ );
+		ASSERT_GE( env.NeighborLength, r_eByl_0*l0 * (1+ courant*2) ); // 近傍粒子として保持する距離が、クーラン数による距離の二倍以上か？
 	}
 
-}
+	}//openmps
+
+}//anonymas
+
+	///#ifndef PRESSURE_EXPLICIT
+	///				const double eps = 1e-10;
+	///					const double c = 1.0;
+	/////		const double C; // env
+	///#endif
+	///#ifdef ARTIFICIAL_COLLISION_FORCE
+	///				const double tooNearRatio = 1.0;
+	///				const double tooNearCoefficient = 1.0;
+	///#endif
+	///
+	///				const double startTime = 0.0;
+	///				const double endTime = 0.5;
+	///				const double outputInterval = 0.0;
+	///				const std::size_t minStepCountPerOutput = 100;

--- a/src/OpenMps/test/test_ComputerDensity.cpp
+++ b/src/OpenMps/test/test_ComputerDensity.cpp
@@ -40,6 +40,10 @@ namespace{
 				const double maxX = 0.053;
 				const double maxZ = 0.1;
 
+				// 格子状に配置する際の1辺あたりの粒子数
+			const int num_ps_x = 7;
+			const int num_ps_z = 7;
+
 #ifdef PRESSURE_EXPLICIT
 					const double c = 1.0;
 #endif
@@ -92,6 +96,26 @@ namespace{
 
 			computer = new OpenMps::Computer<POS_WALL,POS_WALL_PRE>(std::move(comp));
 
+			// 粒子配置
+			std::vector<OpenMps::Particle> particles;
+
+			// 1辺l0, nx*nyの正方格子状に粒子を配置
+			for(int j = 0; j < num_ps_z; ++j){
+				for(int i = 0; i < num_ps_x; ++i){
+					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
+					particle.X()[OpenMps::AXIS_X] = i*l0;
+					particle.X()[OpenMps::AXIS_Z] = j*l0;;
+
+					particle.U()[OpenMps::AXIS_X] = 0.0;
+					particle.U()[OpenMps::AXIS_Z] = 0.0;
+					particle.P() = 0.0;
+					particle.N() = 0.0;
+
+					particles.push_back(std::move(particle));
+				}
+			}
+			computer->AddParticles(std::move(particles));
+
 		}
 
 		virtual void TearDown(){
@@ -99,7 +123,8 @@ namespace{
 		}
   };
 
-	TEST_F(DensityTest, EnvConstructor){
+	// アクセッサが適切か/フィールドに設定されているか for Environment
+	TEST_F(DensityTest, FieldEnvironment){
 		auto env = computer->GetEnvironment();
 
 		// Environment TODO: PRESSURE_EXPLICITのifdef
@@ -109,20 +134,38 @@ namespace{
 		ASSERT_DOUBLE_EQ( env.MaxDx, l0*courant ); // PRESSURE_EXPLICITで分岐必要
 		ASSERT_DOUBLE_EQ( env.L_0, l0 );
 		ASSERT_DOUBLE_EQ( env.R_e, r_eByl_0*l0 );
-		ASSERT_DOUBLE_EQ( env.G[0], 0.0 );
-		ASSERT_DOUBLE_EQ( env.G[1], -g );
+		ASSERT_DOUBLE_EQ( env.G[OpenMps::AXIS_X], 0.0 );
+		ASSERT_DOUBLE_EQ( env.G[OpenMps::AXIS_Z], -g );
 		ASSERT_DOUBLE_EQ( env.Rho, rho );
 		ASSERT_DOUBLE_EQ( env.Nu, nu );
 		ASSERT_DOUBLE_EQ( env.SurfaceRatio, surfaceRatio );
-		ASSERT_DOUBLE_EQ( env.MinX[0], minX );
-		ASSERT_DOUBLE_EQ( env.MinX[1], minZ );
-		ASSERT_DOUBLE_EQ( env.MaxX[0], maxX );
-		ASSERT_DOUBLE_EQ( env.MaxX[1], maxZ );
+		ASSERT_DOUBLE_EQ( env.MinX[OpenMps::AXIS_X], minX );
+		ASSERT_DOUBLE_EQ( env.MinX[OpenMps::AXIS_Z], minZ );
+		ASSERT_DOUBLE_EQ( env.MaxX[OpenMps::AXIS_X], maxX );
+		ASSERT_DOUBLE_EQ( env.MaxX[OpenMps::AXIS_Z], maxZ );
 		ASSERT_GE( env.NeighborLength, r_eByl_0*l0 * (1+ courant*2) ); // 近傍粒子として保持する距離が、クーラン数による距離の二倍以上か？
 	}
 
-	}//openmps
+	// アクセッサが適切か/フィールドに設定されているか for Particles
+	TEST_F(DensityTest, FieldParticles){
+		auto particles = computer->Particles();
 
+	 // 粒子数チェック
+		ASSERT_EQ( particles.size(), num_ps_x*num_ps_z );
+
+		// 辺の長さが num_ps_x*l0, num_ps_z*l0 の長方形の内部に存在するか？
+		for(const auto& p : particles){
+			const double px = p.X()[OpenMps::AXIS_X];
+			const double pz = p.X()[OpenMps::AXIS_Z];
+			ASSERT_LE( px, (num_ps_x-1)*l0 );
+			ASSERT_GE( px, 0 );
+			ASSERT_LE( pz, (num_ps_z-1)*l0 );
+			ASSERT_GE( pz, 0 );
+		}
+	}
+
+
+	}//openmps
 }//anonymas
 
 	///#ifndef PRESSURE_EXPLICIT

--- a/src/OpenMps/test/test_ComputerDensity.cpp
+++ b/src/OpenMps/test/test_ComputerDensity.cpp
@@ -10,6 +10,7 @@
 #include "../ComputingCondition.hpp"
 
 namespace{
+	namespace OpenMps{
 	double positionWall(std::size_t, double, double){
 		return 0.0;
 	}
@@ -137,6 +138,7 @@ namespace{
 		// 粒子数を表示
 		std::cout << particles.size() << " particles" << std::endl;
 
+	}
 	}
 
 }

--- a/src/OpenMps/test/test_ComputerDensity.cpp
+++ b/src/OpenMps/test/test_ComputerDensity.cpp
@@ -5,6 +5,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
+#define TEST_DENSITY
 #include "../Computer.hpp"
 #include "../Particle.hpp"
 

--- a/src/OpenMps/test/test_ComputerDensity.cpp
+++ b/src/OpenMps/test/test_ComputerDensity.cpp
@@ -1,0 +1,142 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include <cstdio>
+#include <boost/format.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include "../Computer.hpp"
+#include "../Particle.hpp"
+#include "../ComputingCondition.hpp"
+
+namespace{
+	double positionWall(std::size_t, double, double){
+		return 0.0;
+	}
+
+	double positionWallPre(double, double){
+		return 0.0;
+	}
+	typedef double (&POS_WALL)(std::size_t,double,double);
+	typedef double (&POS_WALL_PRE)(double,double);
+
+	class DensityTest : public ::testing::Test
+	{
+		protected:
+			OpenMps::Computer<POS_WALL,POS_WALL_PRE> *computer;
+
+			// それぞれのテストケースTEST_Fが呼ばれる直前にSetUpで初期化される
+			virtual void SetUp(){
+				printf("Setup\n");
+
+#ifndef PRESSURE_EXPLICIT
+				const double eps = 1e-10;
+#endif
+#ifdef ARTIFICIAL_COLLISION_FORCE
+				const double tooNearRatio = 1.0;
+				const double tooNearCoefficient = 1.0;
+#endif
+
+				const double startTime = 0.0;
+				const double endTime = 0.5;
+				const double outputInterval = 0.0;
+				const std::size_t minStepCountPerOutput = 100;
+				const double courant = 0.1;
+				const double l0 = 0.001;
+
+				const double g = 9.8;
+				const double rho = 998.2;
+				const double nu = 1.004e-06;
+				const double r_eByl_0 = 2.4;
+				const double surfaceRatio = 0.95;
+				const double minX = -0.004;
+				const double minZ = -0.004;
+				const double maxX = 0.053;
+				const double maxZ = 0.1;
+
+#ifdef PRESSURE_EXPLICIT
+	const double c = 1.0;
+#endif
+
+		auto&& condition = OpenMps::ComputingCondition(
+#ifndef PRESSURE_EXPLICIT
+				eps,
+#endif
+				startTime, endTime,
+				outputInterval
+				);
+
+		auto&& environment = OpenMps::Environment(outputInterval / minStepCountPerOutput, courant,
+#ifdef ARTIFICIAL_COLLISION_FORCE
+			tooNearRatio, tooNearCoefficient,
+#endif
+			g, rho, nu, surfaceRatio, r_eByl_0,
+#ifdef PRESSURE_EXPLICIT
+			c,
+#endif
+			l0,
+			minX, minZ,
+			maxX, maxZ
+		);
+
+		OpenMps::Computer<POS_WALL,POS_WALL_PRE> comp = OpenMps::CreateComputer(
+#ifndef PRESSURE_EXPLICIT
+			condition.Eps,
+#endif
+			environment,
+			positionWall, positionWallPre);
+
+			computer = new OpenMps::Computer<POS_WALL,POS_WALL_PRE>(std::move(comp));
+			}
+
+			virtual void TearDown(){
+				printf("TearDown\n");
+				delete computer;
+			}
+
+			void searchNeighbor(){
+				computer->SearchNeighbor();
+			}
+
+			void computeNeighborDensities(){
+				computer->ComputeNeighborDensities();
+			}
+  };
+
+	TEST_F(DensityTest,calcDensity){
+		std::vector<OpenMps::Particle> particles;
+
+		// 粒子を作成して入れていく
+		const double l0 = 0.1*1e-3; // 0.1 mm
+//		const double re = 2.1*l0;
+		const int nx = 7;
+		const int ny = 7;
+
+		// 1辺l0, nx*nyの正方格子状に粒子を配置
+		for(int j = 0; j < ny; ++j){
+			for(int i = 0; i < nx; ++i){
+				auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
+				particle.X()[OpenMps::AXIS_X] = i*l0;
+				particle.X()[OpenMps::AXIS_Z] = j*l0;;
+
+				particle.U()[OpenMps::AXIS_X] = 0.0;
+				particle.U()[OpenMps::AXIS_Z] = 0.0;
+				particle.P() = 0.0;
+				particle.N() = 0.0;
+
+				particles.push_back(std::move(particle));
+			}
+		}
+		computer->AddParticles(std::move(particles));
+
+//				computer.ForwardTime();
+		searchNeighbor();
+		computeNeighborDensities();
+
+		// 24番目の粒子を狙う
+		// 粒子数を表示
+		std::cout << particles.size() << " particles" << std::endl;
+
+	}
+
+}

--- a/src/OpenMps/test/test_ComputerDensity.cpp
+++ b/src/OpenMps/test/test_ComputerDensity.cpp
@@ -10,164 +10,161 @@
 
 namespace{
 #ifndef PRESSURE_EXPLICIT
-				const double eps = 1e-10;
+	const double eps = 1e-10;
 #endif
 
-				const double dt_step = 1.0 / 100;
-				const double courant = 0.1;
+	const double dt_step = 1.0 / 100;
+	const double courant = 0.1;
 
-				const double l0 = 0.001;
-				const double g = 9.8;
+	const double l0 = 0.001;
+	const double g = 9.8;
 
-				const double rho = 998.2;
-				const double nu = 1.004e-06;
-				const double r_eByl_0 = 2.4;
-				const double surfaceRatio = 0.95;
-				const double minX = -0.004;
-				const double minZ = -0.004;
-				const double maxX = 0.053;
-				const double maxZ = 0.1;
+	const double rho = 998.2;
+	const double nu = 1.004e-06;
+	const double r_eByl_0 = 2.4;
+	const double surfaceRatio = 0.95;
+	const double minX = -0.004;
+	const double minZ = -0.004;
+	const double maxX = 0.053;
+	const double maxZ = 0.1;
 
-				// 格子状に配置する際の1辺あたりの粒子数
-			const int num_ps_x = 7;
-			const int num_ps_z = 7;
+	// 格子状に配置する際の1辺あたりの粒子数
+	const int num_ps_x = 7;
+	const int num_ps_z = 9;
 
 #ifdef PRESSURE_EXPLICIT
-					const double c = 1.0;
+	const double c = 1.0;
 #endif
 
 	namespace OpenMps{
-	double positionWall(std::size_t, double, double){
-		return 0.0;
-	}
+		double positionWall(std::size_t, double, double){
+			return 0.0;
+		}
 
-	double positionWallPre(double, double){
-		return 0.0;
-	}
-	typedef double (&POS_WALL)(std::size_t,double,double);
-	typedef double (&POS_WALL_PRE)(double,double);
+		double positionWallPre(double, double){
+			return 0.0;
+		}
 
-	class DensityTest : public ::testing::Test
-	{
-		protected:
-			OpenMps::Computer<POS_WALL,POS_WALL_PRE> *computer;
+		typedef double (&POS_WALL)(std::size_t,double,double);
+		typedef double (&POS_WALL_PRE)(double,double);
 
-			// それぞれのテストケースはTEST_Fが呼ばれる直前にSetUpで初期化される
-			virtual void SetUp(){
+		class DensityTest : public ::testing::Test {
+	    protected:
+				OpenMps::Computer<POS_WALL,POS_WALL_PRE> *computer;
 
-		auto&& environment = OpenMps::Environment(dt_step, courant,
-			g, rho, nu, surfaceRatio, r_eByl_0,
+				// それぞれのテストケースはTEST_Fが呼ばれる直前にSetUpで初期化される
+				virtual void SetUp(){
+					auto&& environment = OpenMps::Environment(dt_step, courant,
+						g, rho, nu, surfaceRatio, r_eByl_0,
 #ifdef PRESSURE_EXPLICIT
-			c,
+						c,
 #endif
-			l0,
-			minX, minZ,
-			maxX, maxZ
-		);
+						l0,
+						minX, minZ,
+						maxX, maxZ
+						);
 
-		OpenMps::Computer<POS_WALL,POS_WALL_PRE> comp = OpenMps::CreateComputer(
+					OpenMps::Computer<POS_WALL,POS_WALL_PRE> comp = OpenMps::CreateComputer(
 #ifndef PRESSURE_EXPLICIT
-				eps,
+						eps,
 #endif
-			environment,
-			positionWall, positionWallPre);
+						environment,
+						positionWall, positionWallPre);
 
-			computer = new OpenMps::Computer<POS_WALL,POS_WALL_PRE>(std::move(comp));
+					computer = new OpenMps::Computer<POS_WALL,POS_WALL_PRE>(std::move(comp));
 
-			// 粒子配置
-			std::vector<OpenMps::Particle> particles;
+					std::vector<OpenMps::Particle> particles;
 
-			// 1辺l0, nx*nyの正方格子状に粒子を配置
-			for(int j = 0; j < num_ps_z; ++j){
-				for(int i = 0; i < num_ps_x; ++i){
-					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
-					particle.X()[OpenMps::AXIS_X] = i*l0;
-					particle.X()[OpenMps::AXIS_Z] = j*l0;;
+					// 1辺l0, num_ps_x*num_ps_zの格子状に粒子を配置
+					for(int j = 0; j < num_ps_z; ++j){
+						for(int i = 0; i < num_ps_x; ++i){
+							auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
+							particle.X()[OpenMps::AXIS_X] = i*l0;
+							particle.X()[OpenMps::AXIS_Z] = j*l0;;
 
-					particle.U()[OpenMps::AXIS_X] = 0.0;
-					particle.U()[OpenMps::AXIS_Z] = 0.0;
-					particle.P() = 0.0;
-					particle.N() = 0.0;
+							particle.U()[OpenMps::AXIS_X] = 0.0;
+							particle.U()[OpenMps::AXIS_Z] = 0.0;
+							particle.P() = 0.0;
+							particle.N() = 0.0;
 
-					particles.push_back(std::move(particle));
+							particles.push_back(std::move(particle));
+						}
+					}
+					computer->AddParticles(std::move(particles));
 				}
+
+				auto getAllowableResidual(){
+					return computer->ppe.allowableResidual;
+				}
+
+				virtual void TearDown(){
+					delete computer;
+				}
+		};
+
+		TEST_F(DensityTest, FieldEnvironment){
+			const auto& env = computer->GetEnvironment();
+
+			// 設定した定数値がフィールド値と一致するか？
+#ifdef PRESSURE_EXPLICIT
+			ASSERT_DOUBLE_EQ( env.C, c );
+#endif
+			// 物性値
+			ASSERT_DOUBLE_EQ( env.G[OpenMps::AXIS_X], 0.0 );
+			ASSERT_DOUBLE_EQ( env.G[OpenMps::AXIS_Z], -g );
+			ASSERT_DOUBLE_EQ( env.Rho, rho );
+			ASSERT_DOUBLE_EQ( env.Nu, nu );
+
+			// 粒子法パラメータ
+			ASSERT_DOUBLE_EQ( env.SurfaceRatio, surfaceRatio );
+			ASSERT_DOUBLE_EQ( env.L_0, l0 );
+			ASSERT_DOUBLE_EQ( env.R_e, r_eByl_0*l0 );
+
+			// 計算範囲
+			ASSERT_DOUBLE_EQ( env.MinX[OpenMps::AXIS_X], minX );
+			ASSERT_DOUBLE_EQ( env.MinX[OpenMps::AXIS_Z], minZ );
+			ASSERT_DOUBLE_EQ( env.MaxX[OpenMps::AXIS_X], maxX );
+			ASSERT_DOUBLE_EQ( env.MaxX[OpenMps::AXIS_Z], maxZ );
+
+			// 時間刻みが各特徴的スケール以下であるか？
+			const double dx_courant = courant*l0;
+			const double dt_grav = std::sqrt(2.0*dx_courant/g);
+			ASSERT_LE( env.MaxDt, dt_step );
+			ASSERT_LE( env.MaxDt, dt_grav );
+#ifdef PRESSURE_EXPLICIT
+			const double dt_sound = dx_courant/c;
+			ASSERT_LE( env.MaxDt, dt_sound );
+#endif
+			// 空間刻みがCFL条件を満足するか？
+			ASSERT_GE( env.MaxDx, dx_courant );
+
+			// 近傍粒子として判定する距離が、クーラン数による距離の1倍以上か？
+			ASSERT_GE( env.NeighborLength, r_eByl_0*l0*(1+courant) );
+		}
+
+		TEST_F(DensityTest, FieldParticles){
+			const auto& particles = computer->Particles();
+
+			// 粒子数チェック
+			ASSERT_EQ( particles.size(), num_ps_x*num_ps_z );
+
+			// 辺の長さが num_ps_x*l0, num_ps_z*l0 の長方形の内部に存在するか？
+			for(const auto& p : particles){
+				const double px = p.X()[OpenMps::AXIS_X];
+				const double pz = p.X()[OpenMps::AXIS_Z];
+				ASSERT_LE( px, (num_ps_x-1)*l0 );
+				ASSERT_GE( px, 0 );
+				ASSERT_LE( pz, (num_ps_z-1)*l0 );
+				ASSERT_GE( pz, 0 );
 			}
-			computer->AddParticles(std::move(particles));
-
 		}
 
-		auto getAllowableResidual(){
-			return computer->ppe.allowableResidual;
-		}
-
-		virtual void TearDown(){
-			delete computer;
-		}
-  };
-
-	TEST_F(DensityTest, FieldEnvironment){
-		auto env = computer->GetEnvironment();
-
-		// 設定した定数値がフィールド値と一致するか？
-#ifdef PRESSURE_EXPLICIT
-		ASSERT_DOUBLE_EQ( env.C, c );
-#endif
-		// 物性値
-		ASSERT_DOUBLE_EQ( env.G[OpenMps::AXIS_X], 0.0 );
-		ASSERT_DOUBLE_EQ( env.G[OpenMps::AXIS_Z], -g );
-		ASSERT_DOUBLE_EQ( env.Rho, rho );
-		ASSERT_DOUBLE_EQ( env.Nu, nu );
-
-		// 粒子法パラメータ
-		ASSERT_DOUBLE_EQ( env.SurfaceRatio, surfaceRatio );
-		ASSERT_DOUBLE_EQ( env.L_0, l0 );
-		ASSERT_DOUBLE_EQ( env.R_e, r_eByl_0*l0 );
-
-		// 計算範囲
-		ASSERT_DOUBLE_EQ( env.MinX[OpenMps::AXIS_X], minX );
-		ASSERT_DOUBLE_EQ( env.MinX[OpenMps::AXIS_Z], minZ );
-		ASSERT_DOUBLE_EQ( env.MaxX[OpenMps::AXIS_X], maxX );
-		ASSERT_DOUBLE_EQ( env.MaxX[OpenMps::AXIS_Z], maxZ );
-
-		// 時間刻みが各特徴的スケール以下であるか？
-		const double dt_grav = std::sqrt(2.0*(courant*l0)/g);
-		ASSERT_LE( env.MaxDt, dt_step );
-		ASSERT_LE( env.MaxDt, dt_grav );
-#ifdef PRESSURE_EXPLICIT
-		const double dt_sound = (courant*l0)/c;
-		ASSERT_LE( env.MaxDt, dt_sound );
-#endif
-
-		// 空間刻みがCFL条件を満足するか？
-		ASSERT_GE( env.MaxDx, l0*courant );
-
-		// 近傍粒子として判定する距離が、クーラン数による距離の1倍以上か？
-		ASSERT_GE( env.NeighborLength, r_eByl_0*l0 * (1+ courant) );
-	}
-
-	TEST_F(DensityTest, FieldParticles){
-		auto particles = computer->Particles();
-
-	 // 粒子数チェック
-		ASSERT_EQ( particles.size(), num_ps_x*num_ps_z );
-
-		// 辺の長さが num_ps_x*l0, num_ps_z*l0 の長方形の内部に存在するか？
-		for(const auto& p : particles){
-			const double px = p.X()[OpenMps::AXIS_X];
-			const double pz = p.X()[OpenMps::AXIS_Z];
-			ASSERT_LE( px, (num_ps_x-1)*l0 );
-			ASSERT_GE( px, 0 );
-			ASSERT_LE( pz, (num_ps_z-1)*l0 );
-			ASSERT_GE( pz, 0 );
-		}
-	}
-
-	TEST_F(DensityTest, FieldComputer){
+		TEST_F(DensityTest, FieldComputer){
+			// 設定した定数値がフィールド値と一致するか？
 #ifndef PRESSURE_EXPLICIT
-      // 圧力方程式の許容誤差
-      ASSERT_DOUBLE_EQ(getAllowableResidual(), eps);
+			ASSERT_DOUBLE_EQ(getAllowableResidual(), eps);
 #endif
-  }
+		}
 
-  }//openmps
-}//anonymas
+	}
+}


### PR DESCRIPTION
OpenMpsは計算初期化において、Computerのコンストラクタに 計算条件Environment, 初期粒子Particles を与える。
Environment, Particles フィールドが適切に設定されているかのテストを記述した > FieldEnvironment, FieldParticles

テスト内容
* Environment: 定数値はそのままコピーされているか、時間・空間刻みは CFL条件を満足するか
* Particles: 粒子数は一致するか、計算空間は一致するか

未着手:
* 設定群: ARTIFICIAL_COLLISION_FORCE, MPS_HL, DIM3
* moveできているか？(単純に行数が増えそうなので、本PRでは一旦フィールド設定のみとした)

