### PR TITLE
testのREADME追加

### DIFF
--- a/src/OpenMps/test/README.md
+++ b/src/OpenMps/test/README.md
@@ -5,14 +5,14 @@ It is recommended to use Visual Studio.
 
 ### Build
 
-0. First, You should build a test library.
+0. You should build a test library.
 	1. Get [Googletest](https://github.com/google/googletest) by yourself.
 		* Googletest should be placed on `src/googletest`. You can use `git submodule`.
 	1. Generate scripts to build the library with `cmake`.
 		* For Visual Studio, You can generate project files(`ALL_BUILD.vcxproj, ...`).
 	1. Build the library. 
 
-0. Second, Build codes in `src/OpenMps/test`.
+0. Build codes in `src/OpenMps/test`.
 
 ### Execution
 

--- a/src/OpenMps/test/README.md
+++ b/src/OpenMps/test/README.md
@@ -1,0 +1,19 @@
+## Usage
+
+There are test programs for OpenMps in this directory.
+It is recommended to use Visual Studio.
+
+### Build
+
+0. First, You should build a test library.
+	1. Get [Googletest](https://github.com/google/googletest) by yourself.
+		* Googletest should be placed on `src/googletest`. You can use `git submodule`.
+	1. Generate scripts to build the library with `cmake`.
+		* For Visual Studio, You can generate project files(`ALL_BUILD.vcxproj, ...`).
+	1. Build the library. 
+
+0. Second, Build codes in `src/OpenMps/test`.
+
+### Execution
+
+0. Run the program (Developers expect execution on Windows). Results will be output in the console window.


### PR DESCRIPTION
* testのREADMEを追加する

* markdown形式 ,  README.md に書式従う

* 内容
    * 実行方法手順
    * ビルド時注意

> いつも作業忘れるのでメモ：Linuxでのgoogletestのビルド時にcmake -DCMAKE_CXX_COMPILER=clang++ ..にしないとgccでビルドされてclangを使っているOpenMps本体とリンクがコケる（どこかに書いたほうが良いかもしれない）
