### PR TITLE
computeExplicitForces() のテスト追加

### DIFF
--- a/src/OpenMps/Computer.hpp
+++ b/src/OpenMps/Computer.hpp
@@ -441,6 +441,9 @@ namespace { namespace OpenMps
 #ifdef TEST_NUMBERDENSITY
 	friend class NumberDensityTest;
 #endif
+#ifdef TEST_EXPLICITFORCES
+	friend class ExplicitForcesTest;
+#endif
 
 	private:
 		// 粒子リスト

--- a/src/OpenMps/test/test.sln
+++ b/src/OpenMps/test/test.sln
@@ -8,19 +8,13 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Debug|x64.ActiveCfg = Debug|x64
-		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Debug|x64.Build.0 = Debug|x64
-		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Debug|x86.ActiveCfg = Debug|Win32
-		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Debug|x86.Build.0 = Debug|Win32
-		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Release|x64.ActiveCfg = Release|x64
-		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Release|x64.Build.0 = Release|x64
-		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Release|x86.ActiveCfg = Release|Win32
-		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Release|x86.Build.0 = Release|Win32
+		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Debug|x64.ActiveCfg = Release|x64
+		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Debug|x64.Build.0 = Release|x64
+		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Release|x64.ActiveCfg = Debug|x64
+		{F85575DC-47F4-48C0-9B77-57635E6B87EF}.Release|x64.Build.0 = Debug|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OpenMps/test/test.vcxproj
+++ b/src/OpenMps/test/test.vcxproj
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
@@ -25,19 +17,6 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -58,12 +37,6 @@
   </ImportGroup>
   <ImportGroup Label="Shared">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -72,17 +45,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -97,21 +59,6 @@
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>$(SolutionDir)..\..\packages\boost_serialization-vc142.1.70.0.0\lib\native;$(SolutionDir)..\..\googletest\lib\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>gtest.lib;gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/src/OpenMps/test/test.vcxproj
+++ b/src/OpenMps/test/test.vcxproj
@@ -138,7 +138,7 @@
     <ClCompile Include="test_ComputerConstructor.cpp" />
     <ClCompile Include="test_ComputerMatrix.cpp" />
     <ClCompile Include="test_ComputerNumberDensity.cpp" />
-    <ClCompile Include="test_ComputerXXX.cpp" />
+    <ClCompile Include="test_ComputerExplicitForces.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/OpenMps/test/test.vcxproj
+++ b/src/OpenMps/test/test.vcxproj
@@ -138,6 +138,7 @@
     <ClCompile Include="test_ComputerConstructor.cpp" />
     <ClCompile Include="test_ComputerMatrix.cpp" />
     <ClCompile Include="test_ComputerNumberDensity.cpp" />
+    <ClCompile Include="test_ComputerXXX.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/OpenMps/test/test_ComputerConstructor.cpp
+++ b/src/OpenMps/test/test_ComputerConstructor.cpp
@@ -3,6 +3,7 @@
 #define TEST_CONSTRUCTOR
 #include "../Computer.hpp"
 #include "../Particle.hpp"
+#include "../Environment.hpp"
 
 namespace {
 #ifndef PRESSURE_EXPLICIT
@@ -18,7 +19,9 @@ namespace {
 	static constexpr double rho = 998.2;
 	static constexpr double nu = 1.004e-06;
 	static constexpr double r_eByl_0 = 2.4;
+#ifndef MPS_SPP
 	static constexpr double surfaceRatio = 0.95;
+#endif
 	static constexpr double minX = -0.004;
 	static constexpr double minZ = -0.004;
 	static constexpr double maxX = 0.053;
@@ -53,7 +56,11 @@ namespace OpenMps
 		virtual void SetUp()
 		{
 			auto&& environment = OpenMps::Environment(dt_step, courant,
-				g, rho, nu, surfaceRatio, r_eByl_0,
+				g, rho, nu,
+#ifndef MPS_SPP
+				surfaceRatio,
+#endif
+				r_eByl_0,
 #ifdef PRESSURE_EXPLICIT
 				c,
 #endif
@@ -121,7 +128,9 @@ namespace OpenMps
 		ASSERT_DOUBLE_EQ( env.Nu, nu );
 
 		// 粒子法パラメータ
+#ifndef MPS_SPP
 		ASSERT_DOUBLE_EQ( env.SurfaceRatio, surfaceRatio );
+#endif
 		ASSERT_DOUBLE_EQ( env.L_0, l0 );
 		ASSERT_DOUBLE_EQ( env.R_e, r_eByl_0*l0 );
 

--- a/src/OpenMps/test/test_ComputerConstructor.cpp
+++ b/src/OpenMps/test/test_ComputerConstructor.cpp
@@ -28,8 +28,8 @@ namespace {
 	static constexpr double maxZ = 0.1;
 
 	// 格子状に配置する際の1辺あたりの粒子数
-	static constexpr int num_ps_x = 7;
-	static constexpr int num_ps_z = 9;
+	static constexpr size_t num_x = 7;
+	static constexpr size_t num_z = 9;
 
 #ifdef PRESSURE_EXPLICIT
 	static constexpr double c = 1.0;
@@ -80,11 +80,21 @@ namespace OpenMps
 
 			std::vector<OpenMps::Particle> particles;
 
-			// 1辺l0, num_ps_x*num_ps_zの格子状に粒子を配置
-			for(int j = 0; j < num_ps_z; ++j)
+			// 1辺l0, num_x*num_zの格子状に粒子を配置
+#ifdef SIGNED_LOOP_COUNTER
+			for (auto jj = std::make_signed_t<decltype(num_z)>{0}; jj < static_cast<std::make_signed_t<decltype(num_z)>>(num_z); jj++)
 			{
-				for(int i = 0; i < num_ps_x; ++i)
+				const auto j = static_cast<decltype(num_z)>(jj);
+
+				for (auto ii = std::make_signed_t<decltype(num_x)>{0}; ii < static_cast<std::make_signed_t<decltype(num_x)>>(num_x); ii++)
 				{
+					const auto i = static_cast<decltype(num_x)>(ii);
+#else
+			for (auto j = decltype(num_z){0}; j < num_z; j++)
+			{
+				for (auto i = decltype(num_x){0}; i < num_x; i++)
+				{
+#endif
 					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
 					particle.X()[OpenMps::AXIS_X] = i*l0;
 					particle.X()[OpenMps::AXIS_Z] = j*l0;;
@@ -161,16 +171,16 @@ namespace OpenMps
 		const auto& particles = computer->Particles();
 
 		// 粒子数チェック
-		ASSERT_EQ( particles.size(), num_ps_x*num_ps_z );
+		ASSERT_EQ( particles.size(), num_x*num_z );
 
-		// 辺の長さが num_ps_x*l0, num_ps_z*l0 の長方形の内部に存在するか？
+		// 辺の長さが num_x*l0, num_z*l0 の長方形の内部に存在するか？
 		for(const auto& p : particles)
 		{
 			const double px = p.X()[OpenMps::AXIS_X];
 			const double pz = p.X()[OpenMps::AXIS_Z];
-			ASSERT_LE( px, (num_ps_x-1)*l0 );
+			ASSERT_LE( px, (num_x-1)*l0 );
 			ASSERT_GE( px, 0 );
-			ASSERT_LE( pz, (num_ps_z-1)*l0 );
+			ASSERT_LE( pz, (num_z-1)*l0 );
 			ASSERT_GE( pz, 0 );
 		}
 	}

--- a/src/OpenMps/test/test_ComputerConstructor.cpp
+++ b/src/OpenMps/test/test_ComputerConstructor.cpp
@@ -28,8 +28,8 @@ namespace {
 	static constexpr double maxZ = 0.1;
 
 	// 格子状に配置する際の1辺あたりの粒子数
-	static constexpr size_t num_x = 7;
-	static constexpr size_t num_z = 9;
+	static constexpr std::size_t num_x = 7;
+	static constexpr std::size_t num_z = 9;
 
 #ifdef PRESSURE_EXPLICIT
 	static constexpr double c = 1.0;

--- a/src/OpenMps/test/test_ComputerConstructor.cpp
+++ b/src/OpenMps/test/test_ComputerConstructor.cpp
@@ -81,20 +81,10 @@ namespace OpenMps
 			std::vector<OpenMps::Particle> particles;
 
 			// 1辺l0, num_x*num_zの格子状に粒子を配置
-#ifdef SIGNED_LOOP_COUNTER
-			for (auto jj = std::make_signed_t<decltype(num_z)>{0}; jj < static_cast<std::make_signed_t<decltype(num_z)>>(num_z); jj++)
-			{
-				const auto j = static_cast<decltype(num_z)>(jj);
-
-				for (auto ii = std::make_signed_t<decltype(num_x)>{0}; ii < static_cast<std::make_signed_t<decltype(num_x)>>(num_x); ii++)
-				{
-					const auto i = static_cast<decltype(num_x)>(ii);
-#else
 			for (auto j = decltype(num_z){0}; j < num_z; j++)
 			{
 				for (auto i = decltype(num_x){0}; i < num_x; i++)
 				{
-#endif
 					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
 					particle.X()[OpenMps::AXIS_X] = i*l0;
 					particle.X()[OpenMps::AXIS_Z] = j*l0;;

--- a/src/OpenMps/test/test_ComputerExplicitForces.cpp
+++ b/src/OpenMps/test/test_ComputerExplicitForces.cpp
@@ -1,0 +1,261 @@
+#include <gtest/gtest.h>
+
+#define TEST_EXPLICITFORCES
+#include "../Computer.hpp"
+#include "../Particle.hpp"
+#include "../Vector.hpp"
+
+#include <cmath>
+#include <cstdio> // あとで消す
+
+namespace {
+#ifndef PRESSURE_EXPLICIT
+	static constexpr double eps = 1e-7;
+#endif
+
+	static constexpr double dt_step = 1.0 / 100;
+	static constexpr double courant = 0.1;
+
+	static constexpr double l0 = 0.01;
+	static constexpr double g = 9.8;
+
+	static constexpr double rho = 998.2;
+	static constexpr double nu = 1.004e-06;
+	static constexpr double r_eByl_0 = 2.1;
+
+#ifndef MPS_SPP
+	static constexpr double surfaceRatio = 0.95;
+#endif
+	// 格子状に配置する際の1辺あたりの粒子数
+	static constexpr int num_x = 7;
+	static constexpr int num_z = 7;
+
+	// サイズ上限を 横 2*l0*num_x, 縦 2*l0*num_z とする
+	static constexpr double minX = -l0 * num_x;
+	static constexpr double minZ = -l0 * num_z;
+	static constexpr double maxX = l0* num_x;
+	static constexpr double maxZ = l0 * num_z;
+
+	// 許容する相対誤差
+	static constexpr double testAccuracy = 1e-3;
+
+
+#ifdef PRESSURE_EXPLICIT
+	static constexpr double c = 1.0;
+#endif
+
+namespace OpenMps
+{
+	Vector positionWall(std::size_t, double, double)
+	{
+
+		return CreateVector(0.0, 0.0); // ベクトルを返すように変換するとかなんとか
+	}
+
+	double positionWallPre(double, double)
+	{
+		return 0.0;
+	}
+
+	class ExplicitForcesTest : public ::testing::Test
+	{
+	protected:
+		OpenMps::Computer<decltype(positionWall)&,decltype(positionWallPre)&> *computer;
+
+		virtual void SetUp()
+		{
+			auto&& environment = OpenMps::Environment(dt_step, courant,
+				g, rho, nu,
+#ifndef MPS_SPP
+				surfaceRatio,
+#endif
+				r_eByl_0,
+#ifdef PRESSURE_EXPLICIT
+				c,
+#endif
+				l0,
+				minX, minZ,
+				maxX, maxZ
+			);
+
+			environment.Dt() = 0.01;
+			environment.SetNextT();
+
+			computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(std::move(
+				OpenMps::CreateComputer(
+	#ifndef PRESSURE_EXPLICIT
+					eps,
+	#endif
+					environment,
+					positionWall, positionWallPre)));
+		}
+
+		auto& GetParticles()
+		{
+			return computer->particles;
+		}
+
+		double R(const Vector& x1, const Vector& x2)
+		{
+			return OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>::R(x1, x2);
+		}
+
+		double R(const Particle& p1, const Particle& p2)
+		{
+			return OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>::R(p1, p2);
+		}
+
+		void SearchNeighbor()
+		{
+			computer->SearchNeighbor();
+		}
+
+		void ComputeNeighborDensities()
+		{
+			computer->ComputeNeighborDensities();
+		}
+
+		void ComputeExplicitForces()
+		{
+			computer->ComputeExplicitForces();
+		}
+
+		virtual void TearDown()
+		{
+			delete computer;
+		}
+	};
+
+	// 粘性応力+重力の計算値は解析解と一致するか？
+	// 二次多項式 ax^2 + bxy + cy^2 + d,
+	// ラプラシアン 2(a+c)
+	TEST_F(ExplicitForcesTest, ForceValuePolynomial)
+	{
+		// 初期条件速度場の係数, O(1)
+		static constexpr double cx1 = -3.0;
+		static constexpr double cx2 = 4.0;
+		static constexpr double cx3 = 5.0;
+		static constexpr double cx4 = -6.0;
+
+		static constexpr double cy1 = 5.0;
+		static constexpr double cy2 = -6.0;
+		static constexpr double cy3 = -7.0;
+		static constexpr double cy4 = 8.0;
+
+		// 1辺l0, num_x*num_zの格子状に粒子を配置
+		std::vector<OpenMps::Particle> particles0;
+		for (int j = 0; j < num_z; ++j)
+		{
+			for (int i = 0; i < num_x; ++i)
+			{
+
+				auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
+				const double x = i * l0;
+				const double z = j * l0;
+				particle.X()[OpenMps::AXIS_X] = x;
+				particle.X()[OpenMps::AXIS_Z] = z;
+
+				particle.U()[OpenMps::AXIS_X] = cx1 * x * x + cx2 * x * z + cx3 * z * z + cx4;
+				particle.U()[OpenMps::AXIS_Z] = cy1 * x * x + cy2 * x * z + cy3 * z * z + cy4;
+				particle.P() = 0.0;
+				particle.N() = 0.0;
+
+				particles0.push_back(std::move(particle));
+			}
+		}
+		computer->AddParticles(std::move(particles0));
+
+		// 近傍粒子探査
+		const auto &env = computer->GetEnvironment();
+		const double dt = dt_step;
+		SearchNeighbor();
+		ComputeNeighborDensities();
+
+		const auto& particles = GetParticles();
+		const auto id = 24; // 中央の粒子を指すID
+
+		// 力を加える前後での速度を取得して加速度計算
+		const double ux0 = particles[id].U()[OpenMps::AXIS_X];
+		const double uy0 = particles[id].U()[OpenMps::AXIS_Z];
+		ComputeExplicitForces();
+		const double ux1 = particles[id].U()[OpenMps::AXIS_X];
+		const double uy1 = particles[id].U()[OpenMps::AXIS_Z];
+
+		const double x = particles[id].X()[OpenMps::AXIS_X];
+		const double z = particles[id].X()[OpenMps::AXIS_Z];
+		const double ax = (ux1 - ux0) / dt_step;
+		const double ay = (uy1 - uy0) / dt_step;
+		const double ax_analy = 2*(cx1+cx3) * nu;
+		const double ay_analy = 2*(cy1+cy3) * nu - g;
+
+		// 相対誤差で評価
+		ASSERT_NEAR( abs( (ax-ax_analy)/ax_analy ), 0.0, testAccuracy);
+		ASSERT_NEAR( abs( (ay-ay_analy)/ay_analy ), 0.0, testAccuracy);
+	}
+
+	// 三角関数 a sin(om * x) + b cos(om' * z) 
+	TEST_F(ExplicitForcesTest, ForceValueSinCos)
+	{
+		// 初期条件速度場の係数
+		static constexpr double cx1 = -3.0;
+		static constexpr double cx2 = 4.0;
+		static constexpr double ox1 = 0.1;
+		static constexpr double ox2 = -0.5;
+
+		static constexpr double cy1 = 3.3;
+		static constexpr double cy2 = -4.0;
+		static constexpr double oy1 = -0.3;
+		static constexpr double oy2 = 0.2;
+
+		// 1辺l0, num_x*num_zの格子状に粒子を配置
+		std::vector<OpenMps::Particle> particles0;
+		for (int j = 0; j < num_z; ++j)
+		{
+			for (int i = 0; i < num_x; ++i)
+			{
+
+				auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
+				const double x = i * l0;
+				const double z = j * l0;
+				particle.X()[OpenMps::AXIS_X] = x;
+				particle.X()[OpenMps::AXIS_Z] = z;
+
+				particle.U()[OpenMps::AXIS_X] = cx1 * sin(ox1*x) + cx2 * cos(ox2*z);
+				particle.U()[OpenMps::AXIS_Z] = cy1 * sin(oy1 * x) + cy2 * cos(oy2 * z);
+				particle.P() = 0.0;
+				particle.N() = 0.0;
+
+				particles0.push_back(std::move(particle));
+			}
+		}
+		computer->AddParticles(std::move(particles0));
+
+		// 近傍粒子探査
+		const auto &env = computer->GetEnvironment();
+		const double dt = dt_step;
+		SearchNeighbor();
+		ComputeNeighborDensities();
+
+		const auto& particles = GetParticles();
+		const auto id = 24; // 中央の粒子を指すID
+
+		// 力を加える前後での速度を取得して加速度計算
+		const double ux0 = particles[id].U()[OpenMps::AXIS_X];
+		const double uy0 = particles[id].U()[OpenMps::AXIS_Z];
+		ComputeExplicitForces();
+		const double ux1 = particles[id].U()[OpenMps::AXIS_X];
+		const double uy1 = particles[id].U()[OpenMps::AXIS_Z];
+
+		const double x = particles[id].X()[OpenMps::AXIS_X];
+		const double z = particles[id].X()[OpenMps::AXIS_Z];
+
+		const double ax = (ux1 - ux0) / dt_step;
+		const double ay = (uy1 - uy0) / dt_step;
+		const double ax_analy = (-ox1*ox1*cx1*sin(ox1*x) - ox2*ox2*cx2*cos(ox2*z)) * nu;
+		const double ay_analy = (-oy1*oy1*cy1*sin(oy1*x) - oy2*oy2*cy2*cos(oy2*z)) * nu - g;
+
+		ASSERT_NEAR( abs( (ax-ax_analy)/ax_analy ), 0.0, testAccuracy);
+		ASSERT_NEAR( abs( (ay-ay_analy)/ay_analy ), 0.0, testAccuracy);
+	}
+}
+}

--- a/src/OpenMps/test/test_ComputerExplicitForces.cpp
+++ b/src/OpenMps/test/test_ComputerExplicitForces.cpp
@@ -6,7 +6,6 @@
 #include "../Vector.hpp"
 
 #include <cmath>
-#include <cstdio> // あとで消す
 
 namespace {
 #ifndef PRESSURE_EXPLICIT
@@ -27,13 +26,13 @@ namespace {
 	static constexpr double surfaceRatio = 0.95;
 #endif
 	// 格子状に配置する際の1辺あたりの粒子数
-	static constexpr int num_x = 7;
-	static constexpr int num_z = 7;
+	static constexpr int num_x = 13;
+	static constexpr int num_z = 13;
 
 	// サイズ上限を 横 2*l0*num_x, 縦 2*l0*num_z とする
 	static constexpr double minX = -l0 * num_x;
 	static constexpr double minZ = -l0 * num_z;
-	static constexpr double maxX = l0* num_x;
+	static constexpr double maxX = l0 * num_x;
 	static constexpr double maxZ = l0 * num_z;
 
 	// 許容する相対誤差
@@ -44,218 +43,210 @@ namespace {
 	static constexpr double c = 1.0;
 #endif
 
-namespace OpenMps
-{
-	Vector positionWall(std::size_t, double, double)
+	namespace OpenMps
 	{
-
-		return CreateVector(0.0, 0.0); // ベクトルを返すように変換するとかなんとか
-	}
-
-	double positionWallPre(double, double)
-	{
-		return 0.0;
-	}
-
-	class ExplicitForcesTest : public ::testing::Test
-	{
-	protected:
-		OpenMps::Computer<decltype(positionWall)&,decltype(positionWallPre)&> *computer;
-
-		virtual void SetUp()
+		Vector positionWall(std::size_t, double, double)
 		{
-			auto&& environment = OpenMps::Environment(dt_step, courant,
-				g, rho, nu,
+
+			return CreateVector(0.0, 0.0);
+		}
+
+		Vector positionWallPre(double, double)
+		{
+			return CreateVector(0.0, 0.0);
+		}
+
+		class ExplicitForcesTest : public ::testing::Test
+		{
+		protected:
+			OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>* computer;
+
+			virtual void SetUp()
+			{
+				auto&& environment = OpenMps::Environment(dt_step, courant,
+					g, rho, nu,
 #ifndef MPS_SPP
-				surfaceRatio,
+					surfaceRatio,
 #endif
-				r_eByl_0,
+					r_eByl_0,
 #ifdef PRESSURE_EXPLICIT
-				c,
+					c,
 #endif
-				l0,
-				minX, minZ,
-				maxX, maxZ
-			);
+					l0,
+					minX, minZ,
+					maxX, maxZ
+				);
 
-			environment.Dt() = 0.01;
-			environment.SetNextT();
+				environment.Dt() = dt_step;
+				environment.SetNextT();
 
-			computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(std::move(
-				OpenMps::CreateComputer(
-	#ifndef PRESSURE_EXPLICIT
-					eps,
-	#endif
-					environment,
-					positionWall, positionWallPre)));
-		}
-
-		auto& GetParticles()
-		{
-			return computer->particles;
-		}
-
-		double R(const Vector& x1, const Vector& x2)
-		{
-			return OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>::R(x1, x2);
-		}
-
-		double R(const Particle& p1, const Particle& p2)
-		{
-			return OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>::R(p1, p2);
-		}
-
-		void SearchNeighbor()
-		{
-			computer->SearchNeighbor();
-		}
-
-		void ComputeNeighborDensities()
-		{
-			computer->ComputeNeighborDensities();
-		}
-
-		void ComputeExplicitForces()
-		{
-			computer->ComputeExplicitForces();
-		}
-
-		virtual void TearDown()
-		{
-			delete computer;
-		}
-	};
-
-	// 粘性応力+重力の計算値は解析解と一致するか？
-	// 二次多項式 ax^2 + bxy + cy^2 + d,
-	// ラプラシアン 2(a+c)
-	TEST_F(ExplicitForcesTest, ForceValuePolynomial)
-	{
-		// 初期条件速度場の係数, O(1)
-		static constexpr double cx1 = -3.0;
-		static constexpr double cx2 = 4.0;
-		static constexpr double cx3 = 5.0;
-		static constexpr double cx4 = -6.0;
-
-		static constexpr double cy1 = 5.0;
-		static constexpr double cy2 = -6.0;
-		static constexpr double cy3 = -7.0;
-		static constexpr double cy4 = 8.0;
-
-		// 1辺l0, num_x*num_zの格子状に粒子を配置
-		std::vector<OpenMps::Particle> particles0;
-		for (int j = 0; j < num_z; ++j)
-		{
-			for (int i = 0; i < num_x; ++i)
-			{
-
-				auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
-				const double x = i * l0;
-				const double z = j * l0;
-				particle.X()[OpenMps::AXIS_X] = x;
-				particle.X()[OpenMps::AXIS_Z] = z;
-
-				particle.U()[OpenMps::AXIS_X] = cx1 * x * x + cx2 * x * z + cx3 * z * z + cx4;
-				particle.U()[OpenMps::AXIS_Z] = cy1 * x * x + cy2 * x * z + cy3 * z * z + cy4;
-				particle.P() = 0.0;
-				particle.N() = 0.0;
-
-				particles0.push_back(std::move(particle));
+				computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(std::move(
+					OpenMps::CreateComputer(
+#ifndef PRESSURE_EXPLICIT
+						eps,
+#endif
+						environment,
+						positionWall, positionWallPre)));
 			}
-		}
-		computer->AddParticles(std::move(particles0));
 
-		// 近傍粒子探査
-		const auto &env = computer->GetEnvironment();
-		const double dt = dt_step;
-		SearchNeighbor();
-		ComputeNeighborDensities();
-
-		const auto& particles = GetParticles();
-		const auto id = 24; // 中央の粒子を指すID
-
-		// 力を加える前後での速度を取得して加速度計算
-		const double ux0 = particles[id].U()[OpenMps::AXIS_X];
-		const double uy0 = particles[id].U()[OpenMps::AXIS_Z];
-		ComputeExplicitForces();
-		const double ux1 = particles[id].U()[OpenMps::AXIS_X];
-		const double uy1 = particles[id].U()[OpenMps::AXIS_Z];
-
-		const double x = particles[id].X()[OpenMps::AXIS_X];
-		const double z = particles[id].X()[OpenMps::AXIS_Z];
-		const double ax = (ux1 - ux0) / dt_step;
-		const double ay = (uy1 - uy0) / dt_step;
-		const double ax_analy = 2*(cx1+cx3) * nu;
-		const double ay_analy = 2*(cy1+cy3) * nu - g;
-
-		// 相対誤差で評価
-		ASSERT_NEAR( abs( (ax-ax_analy)/ax_analy ), 0.0, testAccuracy);
-		ASSERT_NEAR( abs( (ay-ay_analy)/ay_analy ), 0.0, testAccuracy);
-	}
-
-	// 三角関数 a sin(om * x) + b cos(om' * z) 
-	TEST_F(ExplicitForcesTest, ForceValueSinCos)
-	{
-		// 初期条件速度場の係数
-		static constexpr double cx1 = -3.0;
-		static constexpr double cx2 = 4.0;
-		static constexpr double ox1 = 0.1;
-		static constexpr double ox2 = -0.5;
-
-		static constexpr double cy1 = 3.3;
-		static constexpr double cy2 = -4.0;
-		static constexpr double oy1 = -0.3;
-		static constexpr double oy2 = 0.2;
-
-		// 1辺l0, num_x*num_zの格子状に粒子を配置
-		std::vector<OpenMps::Particle> particles0;
-		for (int j = 0; j < num_z; ++j)
-		{
-			for (int i = 0; i < num_x; ++i)
+			auto& GetParticles()
 			{
-
-				auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
-				const double x = i * l0;
-				const double z = j * l0;
-				particle.X()[OpenMps::AXIS_X] = x;
-				particle.X()[OpenMps::AXIS_Z] = z;
-
-				particle.U()[OpenMps::AXIS_X] = cx1 * sin(ox1*x) + cx2 * cos(ox2*z);
-				particle.U()[OpenMps::AXIS_Z] = cy1 * sin(oy1 * x) + cy2 * cos(oy2 * z);
-				particle.P() = 0.0;
-				particle.N() = 0.0;
-
-				particles0.push_back(std::move(particle));
+				return computer->particles;
 			}
+
+			void SearchNeighbor()
+			{
+				computer->SearchNeighbor();
+			}
+
+			void ComputeNeighborDensities()
+			{
+				computer->ComputeNeighborDensities();
+			}
+
+			void ComputeExplicitForces()
+			{
+				computer->ComputeExplicitForces();
+			}
+
+			virtual void TearDown()
+			{
+				delete computer;
+			}
+		};
+
+		// 粘性応力+重力の計算値は解析解と一致するか？
+		// 二次多項式 ax^2 + bxy + cy^2 + d,
+		// ラプラシアン 2(a+c)
+		TEST_F(ExplicitForcesTest, ForceValuePolynomial)
+		{
+			static constexpr double cx1 = -3.0;
+			static constexpr double cx2 = 4.0;
+			static constexpr double cx3 = 5.0;
+			static constexpr double cx4 = -6.0;
+
+			static constexpr double cz1 = 5.0;
+			static constexpr double cz2 = -6.0;
+			static constexpr double cz3 = -7.0;
+			static constexpr double cz4 = 8.0;
+
+			// 1辺l0, num_x*num_zの格子状に粒子を配置
+			std::vector<OpenMps::Particle> particles0;
+			for (int j = 0; j < num_z; ++j)
+			{
+				for (int i = 0; i < num_x; ++i)
+				{
+
+					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
+					const double x = i * l0;
+					const double z = j * l0;
+					particle.X()[OpenMps::AXIS_X] = x;
+					particle.X()[OpenMps::AXIS_Z] = z;
+
+					particle.U()[OpenMps::AXIS_X] = cx1 * x * x + cx2 * x * z + cx3 * z * z + cx4;
+					particle.U()[OpenMps::AXIS_Z] = cz1 * x * x + cz2 * x * z + cz3 * z * z + cz4;
+					particle.P() = 0.0;
+					particle.N() = 0.0;
+
+					particles0.push_back(std::move(particle));
+				}
+			}
+			computer->AddParticles(std::move(particles0));
+
+			// 近傍粒子探索・粒子数密度計算
+			const auto& env = computer->GetEnvironment();
+			SearchNeighbor();
+			ComputeNeighborDensities();
+
+			// 中央粒子の加速度を取得
+			const auto& particles = GetParticles();
+			const auto id = (num_x - 1) / 2 * (num_z + 1);
+
+			const auto v0 = particles[id].U();
+			ComputeExplicitForces();
+			const auto v1 = particles[id].U();
+
+			auto accNum = (v1 - v0) / dt_step;
+
+			// 相対誤差を評価
+			const auto gvec = CreateVector(0.0, -g);
+			const auto visc = CreateVector(2 * (cx1 + cx3) * nu, 2 * (cz1 + cz3) * nu);
+			const auto accAnaly = gvec + visc;
+
+			const auto accDiff = accNum - accAnaly;
+			const auto errx = abs(accDiff[OpenMps::AXIS_X] / accAnaly[OpenMps::AXIS_X]);
+			const auto errz = abs(accDiff[OpenMps::AXIS_Z] / accAnaly[OpenMps::AXIS_Z]);
+
+			ASSERT_NEAR(errx, 0.0, testAccuracy);
+			ASSERT_NEAR(errz, 0.0, testAccuracy);
 		}
-		computer->AddParticles(std::move(particles0));
 
-		// 近傍粒子探査
-		const auto &env = computer->GetEnvironment();
-		const double dt = dt_step;
-		SearchNeighbor();
-		ComputeNeighborDensities();
+		// 三角関数 a sin(om * x) + b cos(om' * z) 
+		TEST_F(ExplicitForcesTest, ForceValueSinCos)
+		{
+			// 初期条件速度場の係数
+			static constexpr double cx1 = -3.0;
+			static constexpr double cx2 = 4.0;
+			static constexpr double ox1 = 0.1;
+			static constexpr double ox2 = -0.5;
 
-		const auto& particles = GetParticles();
-		const auto id = 24; // 中央の粒子を指すID
+			static constexpr double cz1 = 3.3;
+			static constexpr double cz2 = -4.0;
+			static constexpr double oz1 = -0.3;
+			static constexpr double oz2 = 0.2;
 
-		// 力を加える前後での速度を取得して加速度計算
-		const double ux0 = particles[id].U()[OpenMps::AXIS_X];
-		const double uy0 = particles[id].U()[OpenMps::AXIS_Z];
-		ComputeExplicitForces();
-		const double ux1 = particles[id].U()[OpenMps::AXIS_X];
-		const double uy1 = particles[id].U()[OpenMps::AXIS_Z];
+			// 1辺l0, num_x*num_zの格子状に粒子を配置
+			std::vector<OpenMps::Particle> particles0;
+			for (int j = 0; j < num_z; ++j)
+			{
+				for (int i = 0; i < num_x; ++i)
+				{
 
-		const double x = particles[id].X()[OpenMps::AXIS_X];
-		const double z = particles[id].X()[OpenMps::AXIS_Z];
+					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
+					const double x = i * l0;
+					const double z = j * l0;
+					particle.X()[OpenMps::AXIS_X] = x;
+					particle.X()[OpenMps::AXIS_Z] = z;
 
-		const double ax = (ux1 - ux0) / dt_step;
-		const double ay = (uy1 - uy0) / dt_step;
-		const double ax_analy = (-ox1*ox1*cx1*sin(ox1*x) - ox2*ox2*cx2*cos(ox2*z)) * nu;
-		const double ay_analy = (-oy1*oy1*cy1*sin(oy1*x) - oy2*oy2*cy2*cos(oy2*z)) * nu - g;
+					particle.U()[OpenMps::AXIS_X] = cx1 * sin(ox1 * x) + cx2 * cos(ox2 * z);
+					particle.U()[OpenMps::AXIS_Z] = cz1 * sin(oz1 * x) + cz2 * cos(oz2 * z);
+					particle.P() = 0.0;
+					particle.N() = 0.0;
 
-		ASSERT_NEAR( abs( (ax-ax_analy)/ax_analy ), 0.0, testAccuracy);
-		ASSERT_NEAR( abs( (ay-ay_analy)/ay_analy ), 0.0, testAccuracy);
+					particles0.push_back(std::move(particle));
+				}
+			}
+			computer->AddParticles(std::move(particles0));
+
+			const auto& env = computer->GetEnvironment();
+			SearchNeighbor();
+			ComputeNeighborDensities();
+
+			// 中央粒子の加速度を取得
+			const auto& particles = GetParticles();
+			const auto id = (num_x - 1) / 2 * (num_z + 1);
+
+			const auto xvec = particles[id].X();
+			const double x = xvec[OpenMps::AXIS_X];
+			const double z = xvec[OpenMps::AXIS_Z];
+
+			const auto v0 = particles[id].U();
+			ComputeExplicitForces();
+			const auto v1 = particles[id].U();
+			auto accNum = (v1 - v0) / dt_step;
+
+			// 相対誤差を評価
+			const auto gvec = CreateVector(0.0, -g);
+			const auto visc = CreateVector((-ox1 * ox1 * cx1 * sin(ox1 * x) - ox2 * ox2 * cx2 * cos(ox2 * z)) * nu,
+				(-oz1 * oz1 * cz1 * sin(oz1 * x) - oz2 * oz2 * cz2 * cos(oz2 * z)) * nu);
+			const auto accAnaly = gvec + visc;
+
+			const auto accDiff = accNum - accAnaly;
+			const auto errx = abs(accDiff[OpenMps::AXIS_X] / accAnaly[OpenMps::AXIS_X]);
+			const auto errz = abs(accDiff[OpenMps::AXIS_Z] / accAnaly[OpenMps::AXIS_Z]);
+
+			ASSERT_NEAR(errx, 0.0, testAccuracy);
+			ASSERT_NEAR(errz, 0.0, testAccuracy);
+		}
 	}
-}
 }

--- a/src/OpenMps/test/test_ComputerExplicitForces.cpp
+++ b/src/OpenMps/test/test_ComputerExplicitForces.cpp
@@ -177,7 +177,7 @@ namespace {
 			ComputeExplicitForces();
 			const auto v1 = particles[id].U();
 
-			auto accNum = (v1 - v0) / dt_step;
+			const auto accNum = (v1 - v0) / dt_step;
 
 			// ‘Š‘ÎŒë·‚ğ•]‰¿
 			const auto gvec = CreateVector(0.0, -g);
@@ -253,7 +253,7 @@ namespace {
 			const auto v0 = particles[id].U();
 			ComputeExplicitForces();
 			const auto v1 = particles[id].U();
-			auto accNum = (v1 - v0) / dt_step;
+			const auto accNum = (v1 - v0) / dt_step;
 
 			// ‘Š‘ÎŒë·‚ğ•]‰¿
 			const auto gvec = CreateVector(0.0, -g);

--- a/src/OpenMps/test/test_ComputerExplicitForces.cpp
+++ b/src/OpenMps/test/test_ComputerExplicitForces.cpp
@@ -133,20 +133,10 @@ namespace {
 			// 1辺l0, num_x*num_zの格子状に粒子を配置
 			std::vector<OpenMps::Particle> particles0;
 
-#ifdef SIGNED_LOOP_COUNTER
-			for (auto jj = std::make_signed_t<decltype(num_z)>{0}; jj < static_cast<std::make_signed_t<decltype(num_z)>>(num_z); jj++)
-			{
-				const auto j = static_cast<decltype(num_z)>(jj);
-
-				for (auto ii = std::make_signed_t<decltype(num_x)>{0}; ii < static_cast<std::make_signed_t<decltype(num_x)>>(num_x); ii++)
-				{
-					const auto i = static_cast<decltype(num_x)>(ii);
-#else
 			for (auto j = decltype(num_z){0}; j < num_z; j++)
 			{
 				for (auto i = decltype(num_x){0}; i < num_x; i++)
 				{
-#endif
 
 					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
 					const double x = i * l0;
@@ -208,20 +198,10 @@ namespace {
 
 			// 1辺l0, num_x*num_zの格子状に粒子を配置
 			std::vector<OpenMps::Particle> particles0;
-#ifdef SIGNED_LOOP_COUNTER
-			for (auto jj = std::make_signed_t<decltype(num_z)>{0}; jj < static_cast<std::make_signed_t<decltype(num_z)>>(num_z); jj++)
-			{
-				const auto j = static_cast<decltype(num_z)>(jj);
-
-				for (auto ii = std::make_signed_t<decltype(num_x)>{0}; ii < static_cast<std::make_signed_t<decltype(num_x)>>(num_x); ii++)
-				{
-					const auto i = static_cast<decltype(num_x)>(ii);
-#else
 			for (auto j = decltype(num_z){0}; j < num_z; j++)
 			{
 				for (auto i = decltype(num_x){0}; i < num_x; i++)
 				{
-#endif
 					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
 					const double x = i * l0;
 					const double z = j * l0;

--- a/src/OpenMps/test/test_ComputerExplicitForces.cpp
+++ b/src/OpenMps/test/test_ComputerExplicitForces.cpp
@@ -26,8 +26,8 @@ namespace {
 	static constexpr double surfaceRatio = 0.95;
 #endif
 	// 格子状に配置する際の1辺あたりの粒子数
-	static constexpr int num_x = 13;
-	static constexpr int num_z = 13;
+	static constexpr size_t num_x = 13;
+	static constexpr size_t num_z = 13;
 
 	// サイズ上限を 横 2*l0*num_x, 縦 2*l0*num_z とする
 	static constexpr double minX = -l0 * num_x;
@@ -132,10 +132,21 @@ namespace {
 
 			// 1辺l0, num_x*num_zの格子状に粒子を配置
 			std::vector<OpenMps::Particle> particles0;
-			for (int j = 0; j < num_z; ++j)
+
+#ifdef SIGNED_LOOP_COUNTER
+			for (auto jj = std::make_signed_t<decltype(num_z)>{0}; jj < static_cast<std::make_signed_t<decltype(num_z)>>(num_z); jj++)
 			{
-				for (int i = 0; i < num_x; ++i)
+				const auto j = static_cast<decltype(num_z)>(jj);
+
+				for (auto ii = std::make_signed_t<decltype(num_x)>{0}; ii < static_cast<std::make_signed_t<decltype(num_x)>>(num_x); ii++)
 				{
+					const auto i = static_cast<decltype(num_x)>(ii);
+#else
+			for (auto j = decltype(num_z){0}; j < num_z; j++)
+			{
+				for (auto i = decltype(num_x){0}; i < num_x; i++)
+				{
+#endif
 
 					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
 					const double x = i * l0;
@@ -197,11 +208,20 @@ namespace {
 
 			// 1辺l0, num_x*num_zの格子状に粒子を配置
 			std::vector<OpenMps::Particle> particles0;
-			for (int j = 0; j < num_z; ++j)
+#ifdef SIGNED_LOOP_COUNTER
+			for (auto jj = std::make_signed_t<decltype(num_z)>{0}; jj < static_cast<std::make_signed_t<decltype(num_z)>>(num_z); jj++)
 			{
-				for (int i = 0; i < num_x; ++i)
-				{
+				const auto j = static_cast<decltype(num_z)>(jj);
 
+				for (auto ii = std::make_signed_t<decltype(num_x)>{0}; ii < static_cast<std::make_signed_t<decltype(num_x)>>(num_x); ii++)
+				{
+					const auto i = static_cast<decltype(num_x)>(ii);
+#else
+			for (auto j = decltype(num_z){0}; j < num_z; j++)
+			{
+				for (auto i = decltype(num_x){0}; i < num_x; i++)
+				{
+#endif
 					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
 					const double x = i * l0;
 					const double z = j * l0;

--- a/src/OpenMps/test/test_ComputerExplicitForces.cpp
+++ b/src/OpenMps/test/test_ComputerExplicitForces.cpp
@@ -26,8 +26,8 @@ namespace {
 	static constexpr double surfaceRatio = 0.95;
 #endif
 	// 格子状に配置する際の1辺あたりの粒子数
-	static constexpr size_t num_x = 13;
-	static constexpr size_t num_z = 13;
+	static constexpr std::size_t num_x = 13;
+	static constexpr std::size_t num_z = 13;
 
 	// サイズ上限を 横 2*l0*num_x, 縦 2*l0*num_z とする
 	static constexpr double minX = -l0 * num_x;

--- a/src/OpenMps/test/test_ComputerMatrix.cpp
+++ b/src/OpenMps/test/test_ComputerMatrix.cpp
@@ -5,10 +5,17 @@
 namespace {
 	double dist_matrix(const double* M1, const double* M2){
 		double d = 0.0;
-		constexpr double dim = OpenMps::DIM;
+		constexpr std::size_t dim = OpenMps::DIM;
 
-		for(int k = 0; k < dim*dim; ++k){
-			const double diff = M1[k] - M2[k];
+#ifdef SIGNED_LOOP_COUNTER
+		for (auto ii = std::make_signed_t<decltype(dim*dim)>{0}; ii < static_cast<std::make_signed_t<decltype(dim*dim)>>(dim*dim); ii++)
+		{
+			const auto i = static_cast<decltype(dim*dim)>(ii);
+#else
+		for (auto i = decltype(dim*dim){0}; i < dim*dim; i++)
+		{
+#endif
+			const double diff = M1[i] - M2[i];
 			d += diff*diff;
 		}
 		return sqrt(d);

--- a/src/OpenMps/test/test_ComputerMatrix.cpp
+++ b/src/OpenMps/test/test_ComputerMatrix.cpp
@@ -7,14 +7,8 @@ namespace {
 		double d = 0.0;
 		constexpr std::size_t dim = OpenMps::DIM;
 
-#ifdef SIGNED_LOOP_COUNTER
-		for (auto ii = std::make_signed_t<decltype(dim*dim)>{0}; ii < static_cast<std::make_signed_t<decltype(dim*dim)>>(dim*dim); ii++)
-		{
-			const auto i = static_cast<decltype(dim*dim)>(ii);
-#else
 		for (auto i = decltype(dim*dim){0}; i < dim*dim; i++)
 		{
-#endif
 			const double diff = M1[i] - M2[i];
 			d += diff*diff;
 		}

--- a/src/OpenMps/test/test_ComputerNumberDensity.cpp
+++ b/src/OpenMps/test/test_ComputerNumberDensity.cpp
@@ -30,8 +30,8 @@ namespace {
 	static constexpr double maxZ = 0.1;
 
 	// 格子状に配置する際の1辺あたりの粒子数
-	static constexpr int num_x = 7;
-	static constexpr int num_z = 7;
+	static constexpr size_t num_x = 7;
+	static constexpr size_t num_z = 7;
 
 #ifdef PRESSURE_EXPLICIT
 	static constexpr double c = 1.0;
@@ -82,10 +82,20 @@ namespace OpenMps
 			std::vector<OpenMps::Particle> particles;
 
 			// 1辺l0, num_x*num_zの格子状に粒子を配置
-			for (int j = 0; j < num_z; ++j)
+#ifdef SIGNED_LOOP_COUNTER
+			for (auto jj = std::make_signed_t<decltype(num_z)>{0}; jj < static_cast<std::make_signed_t<decltype(num_z)>>(num_z); jj++)
 			{
-				for (int i = 0; i < num_x; ++i)
+				const auto j = static_cast<decltype(num_z)>(jj);
+
+				for (auto ii = std::make_signed_t<decltype(num_x)>{0}; ii < static_cast<std::make_signed_t<decltype(num_x)>>(num_x); ii++)
 				{
+					const auto i = static_cast<decltype(num_x)>(ii);
+#else
+			for (auto j = decltype(num_z){0}; j < num_z; j++)
+			{
+				for (auto i = decltype(num_x){0}; i < num_x; i++)
+				{
+#endif
 					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
 					particle.X()[OpenMps::AXIS_X] = i * l0;
 					particle.X()[OpenMps::AXIS_Z] = j * l0;

--- a/src/OpenMps/test/test_ComputerNumberDensity.cpp
+++ b/src/OpenMps/test/test_ComputerNumberDensity.cpp
@@ -30,8 +30,8 @@ namespace {
 	static constexpr double maxZ = 0.1;
 
 	// 格子状に配置する際の1辺あたりの粒子数
-	static constexpr size_t num_x = 7;
-	static constexpr size_t num_z = 7;
+	static constexpr std::size_t num_x = 7;
+	static constexpr std::size_t num_z = 7;
 
 #ifdef PRESSURE_EXPLICIT
 	static constexpr double c = 1.0;

--- a/src/OpenMps/test/test_ComputerNumberDensity.cpp
+++ b/src/OpenMps/test/test_ComputerNumberDensity.cpp
@@ -82,20 +82,10 @@ namespace OpenMps
 			std::vector<OpenMps::Particle> particles;
 
 			// 1辺l0, num_x*num_zの格子状に粒子を配置
-#ifdef SIGNED_LOOP_COUNTER
-			for (auto jj = std::make_signed_t<decltype(num_z)>{0}; jj < static_cast<std::make_signed_t<decltype(num_z)>>(num_z); jj++)
-			{
-				const auto j = static_cast<decltype(num_z)>(jj);
-
-				for (auto ii = std::make_signed_t<decltype(num_x)>{0}; ii < static_cast<std::make_signed_t<decltype(num_x)>>(num_x); ii++)
-				{
-					const auto i = static_cast<decltype(num_x)>(ii);
-#else
 			for (auto j = decltype(num_z){0}; j < num_z; j++)
 			{
 				for (auto i = decltype(num_x){0}; i < num_x; i++)
 				{
-#endif
 					auto particle = OpenMps::Particle(OpenMps::Particle::Type::IncompressibleNewton);
 					particle.X()[OpenMps::AXIS_X] = i * l0;
 					particle.X()[OpenMps::AXIS_Z] = j * l0;

--- a/src/OpenMps/test/test_ComputerNumberDensity.cpp
+++ b/src/OpenMps/test/test_ComputerNumberDensity.cpp
@@ -21,7 +21,9 @@ namespace {
 	static constexpr double rho = 998.2;
 	static constexpr double nu = 1.004e-06;
 	static constexpr double r_eByl_0 = 2.1;
+#ifndef MPS_SPP
 	static constexpr double surfaceRatio = 0.95;
+#endif
 	static constexpr double minX = -0.004;
 	static constexpr double minZ = -0.004;
 	static constexpr double maxX = 0.053;
@@ -55,7 +57,11 @@ namespace OpenMps
 		virtual void SetUp()
 		{
 			auto&& environment = OpenMps::Environment(dt_step, courant,
-				g, rho, nu, surfaceRatio, r_eByl_0,
+				g, rho, nu,
+#ifndef MPS_SPP
+				surfaceRatio,
+#endif
+				r_eByl_0,
 #ifdef PRESSURE_EXPLICIT
 				c,
 #endif


### PR DESCRIPTION
* computeExplicitForces() は 重力 と 粘性応力 を計算して、加速度に応じて粒子速度・位置を更新する関数である。
* 初期速度分布を 2次関数、三角関数として、1ステップ後の数値解と解析解の相対誤差をテストする。