### PR TITLE
ViennaCLのエラーを解消する

### DIFF
--- a/src/OpenMps/test/test.vcxproj
+++ b/src/OpenMps/test/test.vcxproj
@@ -50,7 +50,6 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\googletest\googletest\include;$(SolutionDir)..\..\packages\boost.1.70.0.0\lib\native\include;$(SolutionDir)..\..\viennacl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -68,7 +67,6 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\googletest\googletest\include;$(SolutionDir)..\..\packages\boost.1.70.0.0\lib\native\include;$(SolutionDir)..\..\viennacl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/src/OpenMps/test/test.vcxproj.filters
+++ b/src/OpenMps/test/test.vcxproj.filters
@@ -16,6 +16,12 @@
     <ClCompile Include="test_ComputerNumberDensity.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="test_ComputerConjugateGradient.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="test_ComputerPressureGradient.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="ソース ファイル">

--- a/src/OpenMps/test/test_ComputerConjugateGradient.cpp
+++ b/src/OpenMps/test/test_ComputerConjugateGradient.cpp
@@ -72,13 +72,12 @@ namespace {
 				environment.Dt() = dt_step;
 				environment.SetNextT();
 
-				computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(std::move(
-					OpenMps::CreateComputer(
+				computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(
 #ifndef PRESSURE_EXPLICIT
 						eps,
 #endif
 						environment,
-						positionWall, positionWallPre)));
+						positionWall, positionWallPre);
 			}
 
 			void SolvePressurePoissonEquation()

--- a/src/OpenMps/test/test_ComputerConjugateGradient.cpp
+++ b/src/OpenMps/test/test_ComputerConjugateGradient.cpp
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+ï»¿#include <gtest/gtest.h>
 
 #define TEST_CONJUGATEGRADIENT
 #include "../Computer.hpp"
@@ -27,7 +27,7 @@ namespace {
 	static constexpr double maxX = l0;
 	static constexpr double maxZ = l0;
 
-	// ‹–—e‚·‚é‘Š‘ÎŒë·
+	// è¨±å®¹ã™ã‚‹ç›¸å¯¾èª¤å·®
 	static constexpr double testAccuracy = 1e-3;
 
 
@@ -182,11 +182,11 @@ namespace {
 			ASSERT_NEAR(ppe.x(3), 8.0, testAccuracy);
 		}
 
-		// 1ŸŒ³í”÷•ª•û’ö® d^2f/dx^2 = x ‚ğ‹¤–ğŒù”z–@‚Å‰ğ‚«A‰ğÍ‰ğ‚Æ”äŠr
-		// f(0) = a,  f(1) = b ‚Ì‚Æ‚«Af(x) = 1/6 x^3 + (b-a-1/6)x + a
+		// 1æ¬¡å…ƒå¸¸å¾®åˆ†æ–¹ç¨‹å¼ d^2f/dx^2 = x ã‚’å…±å½¹å‹¾é…æ³•ã§è§£ãã€è§£æè§£ã¨æ¯”è¼ƒ
+		// f(0) = a,  f(1) = b ã®ã¨ãã€f(x) = 1/6 x^3 + (b-a-1/6)x + a
 		TEST_F(ConjugateGradientTest, Solve1dODE)
 		{
-			constexpr auto nx = 10; // ‹«ŠE‚ğŠÜ‚ß‚½“_”‚ªnx+2
+			constexpr auto nx = 10; // å¢ƒç•Œã‚’å«ã‚ãŸç‚¹æ•°ãŒnx+2
 			constexpr double dx = 1.0 / (nx + 1);
 			constexpr double dx2 = dx * dx;
 
@@ -218,7 +218,7 @@ namespace {
 
 			SolvePressurePoissonEquation();
 
-			// ‰ğÍ‰ğ‚Æ‚Ì‘Š‘ÎŒë·‚ğŒvZ
+			// è§£æè§£ã¨ã®ç›¸å¯¾èª¤å·®ã‚’è¨ˆç®—
 			double diff = 0.0;
 			for (auto j = decltype(nx){0}; j < nx; j++)
 			{

--- a/src/OpenMps/test/test_ComputerConstructor.cpp
+++ b/src/OpenMps/test/test_ComputerConstructor.cpp
@@ -67,14 +67,12 @@ namespace OpenMps
 				maxX, maxZ
 				);
 
-			OpenMps::Computer<decltype(positionWall)&,decltype(positionWallPre)&> comp = OpenMps::CreateComputer(
+			computer = new OpenMps::Computer<decltype(positionWall)&,decltype(positionWallPre)&>(
 #ifndef PRESSURE_EXPLICIT
 				eps,
 #endif
 				environment,
 				positionWall, positionWallPre);
-
-			computer = new OpenMps::Computer<decltype(positionWall)&,decltype(positionWallPre)&>(std::move(comp));
 
 			std::vector<OpenMps::Particle> particles;
 

--- a/src/OpenMps/test/test_ComputerExplicitForces.cpp
+++ b/src/OpenMps/test/test_ComputerExplicitForces.cpp
@@ -78,13 +78,12 @@ namespace {
 				environment.Dt() = dt_step;
 				environment.SetNextT();
 
-				computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(std::move(
-					OpenMps::CreateComputer(
+				computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(
 #ifndef PRESSURE_EXPLICIT
 						eps,
 #endif
 						environment,
-						positionWall, positionWallPre)));
+						positionWall, positionWallPre);
 			}
 
 			auto& GetParticles()

--- a/src/OpenMps/test/test_ComputerImplicitForces.cpp
+++ b/src/OpenMps/test/test_ComputerImplicitForces.cpp
@@ -76,13 +76,12 @@ namespace {
 				environment.Dt() = dt_step;
 				environment.SetNextT();
 
-				computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(std::move(
-					OpenMps::CreateComputer(
+				computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(
 #ifndef PRESSURE_EXPLICIT
 						eps,
 #endif
 						environment,
-						positionWall, positionWallPre)));
+						positionWall, positionWallPre);
 
 				std::vector<OpenMps::Particle> particles0;
 

--- a/src/OpenMps/test/test_ComputerNumberDensity.cpp
+++ b/src/OpenMps/test/test_ComputerNumberDensity.cpp
@@ -69,13 +69,12 @@ namespace OpenMps
 			);
 
 
-			computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(std::move(
-				OpenMps::CreateComputer(
+			computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(
 	#ifndef PRESSURE_EXPLICIT
 					eps,
 	#endif
 					environment,
-					positionWall, positionWallPre)));
+					positionWall, positionWallPre);
 
 			std::vector<OpenMps::Particle> particles;
 

--- a/src/OpenMps/test/test_ComputerPressureGradient.cpp
+++ b/src/OpenMps/test/test_ComputerPressureGradient.cpp
@@ -73,13 +73,12 @@ namespace {
 				environment.Dt() = dt_step;
 				environment.SetNextT();
 
-				computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(std::move(
-					OpenMps::CreateComputer(
+				computer = new OpenMps::Computer<decltype(positionWall)&, decltype(positionWallPre)&>(
 #ifndef PRESSURE_EXPLICIT
 						eps,
 #endif
 						environment,
-						positionWall, positionWallPre)));
+						positionWall, positionWallPre);
 			}
 
 			auto& GetEnvironment()

--- a/src/OpenMps/test/test_ComputerPressureGradient.cpp
+++ b/src/OpenMps/test/test_ComputerPressureGradient.cpp
@@ -4,6 +4,7 @@
 #include "../Computer.hpp"
 #include <cmath>
 #include <iostream>
+#include <boost/math/constants/constants.hpp>
 
 namespace {
 #ifndef PRESSURE_EXPLICIT
@@ -189,7 +190,9 @@ namespace {
 		{
 			std::vector<OpenMps::Particle> particles;
 
-			static constexpr auto wavek = 2.0*M_PI / (10.0*r_eByl_0);
+			constexpr auto PI = boost::math::constants::pi<double>();
+
+			static constexpr auto wavek = 2.0*PI / (10.0*r_eByl_0);
 			static constexpr auto gradpx = 1.0;
 			static constexpr auto gradpz = -1.0;
 

--- a/src/OpenMps/test/test_ComputerPressureGradient.cpp
+++ b/src/OpenMps/test/test_ComputerPressureGradient.cpp
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+﻿#include <gtest/gtest.h>
 
 #define TEST_PRESSUREGRADIENT
 #include "../Computer.hpp"
@@ -154,7 +154,7 @@ namespace {
 			auto p = GetParticles();
 			auto env = GetEnvironment();
 			const auto prefact = (-env.Dt()) / env.Rho;
-
+			
 			// 壁から離れた部分で圧力勾配を解析解と比較
 			for (auto j = decltype(num_z){wallMargin}; j < num_z-wallMargin; j++)
 			{


### PR DESCRIPTION
#50 がたまたま手元で再現したので試したところ、[/permissive](https://docs.microsoft.com/ja-jp/cpp/build/reference/permissive-standards-conformance?view=vs-2019)が指定されていてなんでだろう？と不思議に思って切ってみたらエラーが消えました（他に問題は起きているが）